### PR TITLE
Fix code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/Python/extrator_url.py
+++ b/Python/extrator_url.py
@@ -15,7 +15,7 @@ class ExtratorURL:
         if not self.url:
             raise ValueError("A URL está vazia")
 
-        padrao_url = re.compile('(http(s)?://)?(www.)?bytebank.com(.br)?/cambio')
+        padrao_url = re.compile(r'(http(s)?://)?(www\.)?bytebank\.com(\.br)?/cambio')
         match = padrao_url.match(url)
         if not match:
             raise ValueError("A URL não é válida.")


### PR DESCRIPTION
Fixes [https://github.com/IzaacCoding36/Python_testes/security/code-scanning/1](https://github.com/IzaacCoding36/Python_testes/security/code-scanning/1)

To fix the problem, we need to escape the `.` characters in the regular expression to ensure they match only literal dots. This can be done by replacing each `.` with `\.`. This change will make the regular expression more precise and prevent unintended matches.

The specific change required is in the `valida_url` method of the `ExtratorURL` class, where the regular expression is defined. We need to update the regular expression on line 18 to escape the `.` characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
