### PR TITLE
Fix code scanning alert no. 2: Incomplete regular expression for hostnames

### DIFF
--- a/Python/validador_url.py
+++ b/Python/validador_url.py
@@ -20,7 +20,7 @@ Exemplos de URL inválidas:
 import re
 
 url = 'www.bytebank.com.br/cambio'
-padrao_url = re.compile('(http(s)?://)?(www.)?bytebank.com(.br)?/cambio')
+padrao_url = re.compile(r'(http(s)?://)?(www\.)?bytebank\.com(\.br)?/cambio')
 match = padrao_url.match(url)
 
 if not match:


### PR DESCRIPTION
Fixes [https://github.com/IzaacCoding36/Python_testes/security/code-scanning/2](https://github.com/IzaacCoding36/Python_testes/security/code-scanning/2)

To fix the problem, we need to escape the `.` characters in the regular expression to ensure they match literal dots rather than any character. This can be done by prefixing each `.` with a backslash (`\`). The corrected regular expression should be `(http(s)?://)?(www\.)?bytebank\.com(\.br)?/cambio`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
